### PR TITLE
feat(navigation): add aria-label attribute to previous and next posts

### DIFF
--- a/components/post/navigation.js
+++ b/components/post/navigation.js
@@ -8,7 +8,12 @@ const Previous = ({ previous, next }) => {
       <div className={styles.previous}>
         {previous && (
           <Link href="/[slug]" gray as={`/${previous.slug}`}>
-            <div className={styles.title}>← {previous.title}</div>
+            <div
+              aria-label={`Previous post: ${previous.title}`}
+              className={styles.title}
+            >
+              ← {previous.title}
+            </div>
           </Link>
         )}
       </div>
@@ -16,7 +21,12 @@ const Previous = ({ previous, next }) => {
       <div className={styles.next}>
         {next && (
           <Link href="/[slug]" gray as={`/${next.slug}`}>
-            <div className={styles.title}>{next.title} →</div>
+            <div
+              aria-label={`Next post: ${next.title}`}
+              className={styles.title}
+            >
+              {next.title} →
+            </div>
           </Link>
         )}
       </div>


### PR DESCRIPTION
Hi! 👋 

Small change to improve usage with screen readers. Currently, it says `${title} left/right arrow`.

Thank you for the posts, it's been great to read them.