### PR TITLE
Suggested improvement: sort order of posts by date

### DIFF
--- a/lib/get-posts.js
+++ b/lib/get-posts.js
@@ -1,29 +1,27 @@
-import matter from 'gray-matter'
-import fs from 'fs'
-import path from 'path'
+const fs = require('fs')
+const path = require('path')
+const matter = require('gray-matter')
 
-export default () => {
+module.exports = (isRss) => {
   let dir
   try {
-    dir = fs.readdirSync('./posts/')
+    dir = (!isRss)
+      ? fs.readdirSync('./posts/')
+      : fs.readdirSync(path.resolve(__dirname, '../posts/'))
   } catch (err) {
-    // No posts yet
+    // No posts.
     return []
   }
-  const posts = dir
+
+  return dir
     .filter(file => path.extname(file) === '.md')
     .map(file => {
       const postContent = fs.readFileSync(`./posts/${file}`, 'utf8')
       const { data, content } = matter(postContent)
-
       if (data.published === false) {
         return null
       }
-
       return { ...data, body: content, title: data.title.replace(' ', ' ') }
     })
-    .filter(Boolean)
-    .sort((a, b) => a.slug.localeCompare(b.slug))
-
-  return posts
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
 }

--- a/lib/rss.js
+++ b/lib/rss.js
@@ -2,26 +2,7 @@ const fs = require('fs')
 const RSS = require('rss')
 const path = require('path')
 const marked = require('marked')
-const matter = require('gray-matter')
-
-const getPosts = () => {
-  let dir
-  try {
-    dir = fs.readdirSync(path.resolve(__dirname, '../posts/'))
-  } catch (err) {
-    // No posts.
-    return []
-  }
-
-  return dir
-    .filter(file => path.extname(file) === '.md')
-    .map(file => {
-      const postContent = fs.readFileSync(`./posts/${file}`, 'utf8')
-      const { data, content } = matter(postContent)
-      return { ...data, body: content }
-    })
-    .sort((a, b) => new Date(b.date) - new Date(a.date))
-}
+const getPosts = require('./get-posts')
 
 const renderer = new marked.Renderer()
 
@@ -45,7 +26,8 @@ const main = () => {
     language: 'en'
   })
 
-  const posts = getPosts()
+  const isRss = true;
+  const posts = getPosts(isRss)
   posts.forEach(post => {
     const url = `https://whatthefuck.is/${post.slug}`
 


### PR DESCRIPTION
Enjoing this glossary very much. However if reading
irregulary it is hard to know (might be subjective)
which terms were recently added without using rss.
Suggesting to make sort order of terms same as in rss feed items.